### PR TITLE
ATLAB-2631 enable relative load image in io.image loader

### DIFF
--- a/rcnn/core/loader.py
+++ b/rcnn/core/loader.py
@@ -237,7 +237,7 @@ class FPNAnchorLoader(mx.io.DataIter):
 class AnchorLoaderFPN(mx.io.DataIter):
     def __init__(self, feat_sym, roidb, batch_size=1, shuffle=False, ctx=None, work_load_list=None,
                  feat_stride=[4,8,16,32], anchor_scales=(16), anchor_ratios=(0.5, 1, 2), allowed_border=0,
-                 aspect_grouping=False,use_data_augmentation=False):
+                 aspect_grouping=False,use_data_augmentation=False, relative_path=""):
         """
         This Iter will provide roi data to Fast R-CNN network
         :param feat_sym: to infer shape of assign_output
@@ -247,6 +247,8 @@ class AnchorLoaderFPN(mx.io.DataIter):
         :param ctx: list of contexts
         :param work_load_list: list of work load
         :param aspect_grouping: group images with similar aspects
+        :param use_data_augmentation: bool
+        :param relative_path: sample relative base path
         :return: AnchorLoader
         """
         super(AnchorLoaderFPN, self).__init__()
@@ -266,6 +268,7 @@ class AnchorLoaderFPN(mx.io.DataIter):
         self.allowed_border = allowed_border
         self.aspect_grouping = aspect_grouping
         self.use_data_augmentation = use_data_augmentation
+        self.relative_path = relative_path
 
         # infer properties from roidb
         self.size = len(roidb)
@@ -386,7 +389,7 @@ class AnchorLoaderFPN(mx.io.DataIter):
         for islice in slices:
             iroidb = [roidb[i] for i in range(islice.start, islice.stop)]
             #print('get_rpn_batch')
-            data, label = get_rpn_batch(iroidb, self.use_data_augmentation)
+            data, label = get_rpn_batch(iroidb, self.use_data_augmentation, self.relative_path)
             data_list.append(data)
             label_list.append(label)
 	
@@ -452,11 +455,11 @@ class AnchorLoaderFPN(mx.io.DataIter):
         #print(len(anchors))
         return anchors
 
-    
+
 class AnchorLoader(mx.io.DataIter):
     def __init__(self, feat_sym, roidb, batch_size=1, shuffle=False, ctx=None, work_load_list=None,
                  feat_stride=16, anchor_scales=(8, 16, 32), anchor_ratios=(0.5, 1, 2), allowed_border=0,
-                 aspect_grouping=False, use_data_augmentation=False):
+                 aspect_grouping=False, use_data_augmentation=False, relative_path=""):
         """
         This Iter will provide roi data to Fast R-CNN network
         :param feat_sym: to infer shape of assign_output
@@ -466,6 +469,8 @@ class AnchorLoader(mx.io.DataIter):
         :param ctx: list of contexts
         :param work_load_list: list of work load
         :param aspect_grouping: group images with similar aspects
+        :param use_data_augmentation: bool
+        :param relative_path: sample relative base path
         :return: AnchorLoader
         """
         super(AnchorLoader, self).__init__()
@@ -485,6 +490,7 @@ class AnchorLoader(mx.io.DataIter):
         self.allowed_border = allowed_border
         self.aspect_grouping = aspect_grouping
         self.use_data_augmentation = use_data_augmentation
+        self.relative_path = relative_path
 
         # infer properties from roidb
         self.size = len(roidb)
@@ -593,7 +599,7 @@ class AnchorLoader(mx.io.DataIter):
         label_list = []
         for islice in slices:
             iroidb = [roidb[i] for i in range(islice.start, islice.stop)]
-            data, label = get_rpn_batch(iroidb, self.use_data_augmentation)
+            data, label = get_rpn_batch(iroidb, self.use_data_augmentation, self.relative_path)
             data_list.append(data)
             label_list.append(label)
 

--- a/rcnn/io/image.py
+++ b/rcnn/io/image.py
@@ -6,10 +6,12 @@ from PIL import Image, ImageEnhance
 from ..config import config
 
 
-def get_image(roidb, use_data_augmentation=False):
+def get_image(roidb, use_data_augmentation=False, relative_path=""):
     """
     preprocess image and return processed roidb
     :param roidb: a list of roidb
+    :param use_data_augmentation: bool
+    :param relative_path: sample relative base path
     :return: list of img as in mxnet format
     roidb add new item['im_info']
     0 --- x (width, second dim of im)
@@ -21,8 +23,11 @@ def get_image(roidb, use_data_augmentation=False):
     processed_roidb = []
     for i in range(num_images):
         roi_rec = roidb[i]
-        assert os.path.exists(roi_rec['image']), '%s does not exist'.format(roi_rec['image'])
-        im = cv2.imread(roi_rec['image'])
+        image_path = roi_rec['image']
+        if not os.path.isabs(image_path):
+            image_path = os.path.abspath(os.path.join(relative_path, image_path))
+        assert os.path.exists(image_path), '%s does not exist'.format(image_path)
+        im = cv2.imread(image_path)
         if roidb[i]['flipped']:
             im = im[:, ::-1, :]
         new_rec = roi_rec.copy()

--- a/rcnn/io/rcnn.py
+++ b/rcnn/io/rcnn.py
@@ -44,15 +44,17 @@ def get_rcnn_testbatch(roidb):
     return data, label, im_info
 
 
-def get_rcnn_batch(roidb, use_data_augmentation=False):
+def get_rcnn_batch(roidb, use_data_augmentation=False, relative_path=""):
     """
     return a dict of multiple images
     :param roidb: a list of dict, whose length controls batch size
     ['images', 'flipped'] + ['gt_boxes', 'boxes', 'gt_overlap'] => ['bbox_targets']
+    :param use_data_augmentation: bool
+    :param relative_path: sample relative base path
     :return: data, label
     """
     num_images = len(roidb)
-    imgs, roidb = get_image(roidb, use_data_augmentation)
+    imgs, roidb = get_image(roidb, use_data_augmentation, relative_path)
     im_array = tensor_vstack(imgs)
 
     assert config.TRAIN.BATCH_ROIS % config.TRAIN.BATCH_IMAGES == 0, \
@@ -174,4 +176,3 @@ def sample_rois(rois, fg_rois_per_image, rois_per_image, num_classes,
         expand_bbox_regression_targets(bbox_target_data, num_classes)
 
     return rois, labels, bbox_targets, bbox_weights
-

--- a/rcnn/io/rpn.py
+++ b/rcnn/io/rpn.py
@@ -38,14 +38,16 @@ def get_rpn_testbatch(roidb):
     return data, label, im_info
 
 
-def get_rpn_batch(roidb, use_data_augmentation = False):
+def get_rpn_batch(roidb, use_data_augmentation = False, relative_path=""):
     """
     prototype for rpn batch: data, im_info, gt_boxes
     :param roidb: ['image', 'flipped'] + ['gt_boxes', 'boxes', 'gt_classes']
+    :param use_data_augmentation: bool
+    :param relative_path: sample relative base path
     :return: data, label
     """
     assert len(roidb) == 1, 'Single batch only'
-    imgs, roidb = get_image(roidb, use_data_augmentation)
+    imgs, roidb = get_image(roidb, use_data_augmentation, relative_path)
     im_array = imgs[0]
     im_info = np.array([roidb[0]['im_info']], dtype=np.float32)
 


### PR DESCRIPTION
# Expected Behavior

in some cases, trainer need to load images from relative path.

# Current Behavior

It's only allow to load image from absolute path in roidb

# Solution

add `relative_path` parameter in relative methods, and load image from relative path when necessary
